### PR TITLE
Set port of Webpack's dev server to 8081

### DIFF
--- a/front/webpack.dev.js
+++ b/front/webpack.dev.js
@@ -6,5 +6,6 @@ module.exports = merge(common, {
     devtool: "inline-source-map",
     devServer: {
         static: "./dist",
+        port: 8081,
     },
 });


### PR DESCRIPTION
Right now, it's default is 8080, but this causes problems if first the
frontend is started and then the backend.

The other way around, first starting the backend and then the frontend
does not cause problems because the frontend will use port 8081 if 8080
is taken.

The fix is to always use 8081 for Webpack's dev server.