### PR TITLE
Remove push trigger from 'check' workflow

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -5,8 +5,6 @@ on:
     workflow_call:
     pull_request:
         branches: [main]
-    push:
-        branches: [main]
 
 jobs:
     check-pre-commit:


### PR DESCRIPTION
This removes the push trigger from the 'check' workflow, since it will already be run on push in the 'deploy' workflow.