### PR TITLE
Change backend: use the default number of workers

### DIFF
--- a/back/src/main.rs
+++ b/back/src/main.rs
@@ -30,7 +30,6 @@ async fn main() -> std::io::Result<()> {
             .app_data(web::Data::new(game.clone()))
             .route("/", web::get().to(open_socket))
     })
-    .workers(2)
     .bind(addr)?
     .run()
     .await


### PR DESCRIPTION
Instead of always using 2 workers, use the number of cores (the
default).