### PR TITLE
Add support for CSS modules

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,9 @@
             "version": "0.1.0",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {
+                "css-loader": "^6.7.1",
                 "html-webpack-plugin": "^5.5.0",
+                "style-loader": "^3.3.1",
                 "ts-loader": "^9.3.1",
                 "typescript": "^4.7.4",
                 "webpack": "*",
@@ -129,9 +131,9 @@
             }
         },
         "node_modules/@types/eslint": {
-            "version": "8.4.5",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.5.tgz",
-            "integrity": "sha512-dhsC09y1gpJWnK+Ff4SGvCuSnk9DaU0BJZSzOwa6GVSg65XtTugLBITDAAzRU5duGBoXBHpdR/9jHGxJjNflJQ==",
+            "version": "8.4.6",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
+            "integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
             "dev": true,
             "dependencies": {
                 "@types/estree": "*",
@@ -205,9 +207,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "18.7.6",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.6.tgz",
-            "integrity": "sha512-EdxgKRXgYsNITy5mjjXjVE/CS8YENSdhiagGrLqjG0pvA2owgJ6i4l7wy/PFZGC0B1/H20lWKN7ONVDNYDZm7A==",
+            "version": "18.7.13",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.13.tgz",
+            "integrity": "sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw==",
             "dev": true
         },
         "node_modules/@types/qs": {
@@ -773,9 +775,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001378",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001378.tgz",
-            "integrity": "sha512-JVQnfoO7FK7WvU4ZkBRbPjaot4+YqxogSDosHv0Hv5mWpUESmN+UubMU6L/hGz8QlQ2aY5U0vR6MOs6j/CXpNA==",
+            "version": "1.0.30001384",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001384.tgz",
+            "integrity": "sha512-BBWt57kqWbc0GYZXb47wTXpmAgqr5LSibPzNjk/AWMdmJMQhLqOl3c/Kd4OAU/tu4NLfYkMx8Tlq3RVBkOBolQ==",
             "dev": true,
             "funding": [
                 {
@@ -804,18 +806,6 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
-        "node_modules/chalk/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/chokidar": {
             "version": "3.5.3",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -830,7 +820,6 @@
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
-                "fsevents": "~2.3.2",
                 "glob-parent": "~5.1.2",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
@@ -904,10 +893,13 @@
             "dev": true
         },
         "node_modules/commander": {
-            "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "dev": true
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+            "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+            "dev": true,
+            "engines": {
+                "node": ">= 12"
+            }
         },
         "node_modules/compressible": {
             "version": "2.0.18",
@@ -1016,6 +1008,32 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/css-loader": {
+            "version": "6.7.1",
+            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.1.tgz",
+            "integrity": "sha512-yB5CNFa14MbPJcomwNh3wLThtkZgcNyI2bNMRt8iE5Z8Vwl7f8vQXFAzn2HDOJvtDq2NTZBUGMSUNNyrv3/+cw==",
+            "dev": true,
+            "dependencies": {
+                "icss-utils": "^5.1.0",
+                "postcss": "^8.4.7",
+                "postcss-modules-extract-imports": "^3.0.0",
+                "postcss-modules-local-by-default": "^4.0.0",
+                "postcss-modules-scope": "^3.0.0",
+                "postcss-modules-values": "^4.0.0",
+                "postcss-value-parser": "^4.2.0",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": ">= 12.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.0.0"
+            }
+        },
         "node_modules/css-select": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
@@ -1042,6 +1060,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/cssesc": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+            "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+            "dev": true,
+            "bin": {
+                "cssesc": "bin/cssesc"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/debug": {
@@ -1198,9 +1228,9 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.224",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.224.tgz",
-            "integrity": "sha512-dOujC5Yzj0nOVE23iD5HKqrRSDj2SD7RazpZS/b/WX85MtO6/LzKDF4TlYZTBteB+7fvSg5JpWh0sN7fImNF8w==",
+            "version": "1.4.233",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.233.tgz",
+            "integrity": "sha512-ejwIKXTg1wqbmkcRJh9Ur3hFGHFDZDw1POzdsVrB2WZjgRuRMHIQQKNpe64N/qh3ZtH2otEoRoS+s6arAAuAAw==",
             "dev": true
         },
         "node_modules/encodeurl": {
@@ -1531,20 +1561,6 @@
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true
         },
-        "node_modules/fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
-            "hasInstallScript": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
-        },
         "node_modules/function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -1738,15 +1754,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/html-minifier-terser/node_modules/commander": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-            "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-            "dev": true,
-            "engines": {
-                "node": ">= 12"
-            }
-        },
         "node_modules/html-webpack-plugin": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.5.0.tgz",
@@ -1874,6 +1881,18 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/icss-utils": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+            "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+            "dev": true,
+            "engines": {
+                "node": "^10 || ^12 || >= 14"
+            },
+            "peerDependencies": {
+                "postcss": "^8.1.0"
             }
         },
         "node_modules/import-local": {
@@ -2081,6 +2100,21 @@
                 "node": ">= 10.13.0"
             }
         },
+        "node_modules/jest-worker/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -2282,6 +2316,18 @@
             },
             "bin": {
                 "multicast-dns": "cli.js"
+            }
+        },
+        "node_modules/nanoid": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+            "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+            "dev": true,
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
         },
         "node_modules/negotiator": {
@@ -2580,6 +2626,108 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/postcss": {
+            "version": "8.4.16",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
+            "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                }
+            ],
+            "dependencies": {
+                "nanoid": "^3.3.4",
+                "picocolors": "^1.0.0",
+                "source-map-js": "^1.0.2"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/postcss-modules-extract-imports": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
+            "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+            "dev": true,
+            "engines": {
+                "node": "^10 || ^12 || >= 14"
+            },
+            "peerDependencies": {
+                "postcss": "^8.1.0"
+            }
+        },
+        "node_modules/postcss-modules-local-by-default": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
+            "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
+            "dev": true,
+            "dependencies": {
+                "icss-utils": "^5.0.0",
+                "postcss-selector-parser": "^6.0.2",
+                "postcss-value-parser": "^4.1.0"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >= 14"
+            },
+            "peerDependencies": {
+                "postcss": "^8.1.0"
+            }
+        },
+        "node_modules/postcss-modules-scope": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
+            "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
+            "dev": true,
+            "dependencies": {
+                "postcss-selector-parser": "^6.0.4"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >= 14"
+            },
+            "peerDependencies": {
+                "postcss": "^8.1.0"
+            }
+        },
+        "node_modules/postcss-modules-values": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+            "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+            "dev": true,
+            "dependencies": {
+                "icss-utils": "^5.0.0"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >= 14"
+            },
+            "peerDependencies": {
+                "postcss": "^8.1.0"
+            }
+        },
+        "node_modules/postcss-selector-parser": {
+            "version": "6.0.10",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+            "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+            "dev": true,
+            "dependencies": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/postcss-value-parser": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+            "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+            "dev": true
         },
         "node_modules/pretty-error": {
             "version": "4.0.0",
@@ -3095,6 +3243,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/source-map-js": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/source-map-support": {
             "version": "0.5.21",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -3220,19 +3377,32 @@
                 "node": ">=6"
             }
         },
+        "node_modules/style-loader": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
+            "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 12.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.0.0"
+            }
+        },
         "node_modules/supports-color": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
             "dev": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
             "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/supports-color?sponsor=1"
+                "node": ">=8"
             }
         },
         "node_modules/supports-preserve-symlinks-flag": {
@@ -3257,9 +3427,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.14.2",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-            "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+            "version": "5.15.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
+            "integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.2",
@@ -3307,6 +3477,12 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/terser/node_modules/commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true
         },
         "node_modules/thunky": {
             "version": "1.1.0",
@@ -3374,9 +3550,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.7.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-            "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+            "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -3671,9 +3847,9 @@
             }
         },
         "node_modules/webpack-dev-server": {
-            "version": "4.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.10.0.tgz",
-            "integrity": "sha512-7dezwAs+k6yXVFZ+MaL8VnE+APobiO3zvpp3rBHe/HmWQ+avwh0Q3d0xxacOiBybZZ3syTZw9HXzpa3YNbAZDQ==",
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.10.1.tgz",
+            "integrity": "sha512-FIzMq3jbBarz3ld9l7rbM7m6Rj1lOsgq/DyLGMX/fPEB1UBUPtf5iL/4eNfhx8YYJTRlzfv107UfWSWcBK5Odw==",
             "dev": true,
             "dependencies": {
                 "@types/bonjour": "^3.5.9",
@@ -3979,9 +4155,9 @@
             }
         },
         "@types/eslint": {
-            "version": "8.4.5",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.5.tgz",
-            "integrity": "sha512-dhsC09y1gpJWnK+Ff4SGvCuSnk9DaU0BJZSzOwa6GVSg65XtTugLBITDAAzRU5duGBoXBHpdR/9jHGxJjNflJQ==",
+            "version": "8.4.6",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
+            "integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
             "dev": true,
             "requires": {
                 "@types/estree": "*",
@@ -4055,9 +4231,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "18.7.6",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.6.tgz",
-            "integrity": "sha512-EdxgKRXgYsNITy5mjjXjVE/CS8YENSdhiagGrLqjG0pvA2owgJ6i4l7wy/PFZGC0B1/H20lWKN7ONVDNYDZm7A==",
+            "version": "18.7.13",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.13.tgz",
+            "integrity": "sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw==",
             "dev": true
         },
         "@types/qs": {
@@ -4532,9 +4708,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001378",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001378.tgz",
-            "integrity": "sha512-JVQnfoO7FK7WvU4ZkBRbPjaot4+YqxogSDosHv0Hv5mWpUESmN+UubMU6L/hGz8QlQ2aY5U0vR6MOs6j/CXpNA==",
+            "version": "1.0.30001384",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001384.tgz",
+            "integrity": "sha512-BBWt57kqWbc0GYZXb47wTXpmAgqr5LSibPzNjk/AWMdmJMQhLqOl3c/Kd4OAU/tu4NLfYkMx8Tlq3RVBkOBolQ==",
             "dev": true
         },
         "chalk": {
@@ -4545,17 +4721,6 @@
             "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
-            },
-            "dependencies": {
-                "supports-color": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                }
             }
         },
         "chokidar": {
@@ -4622,9 +4787,9 @@
             "dev": true
         },
         "commander": {
-            "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+            "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
             "dev": true
         },
         "compressible": {
@@ -4715,6 +4880,22 @@
                 "which": "^2.0.1"
             }
         },
+        "css-loader": {
+            "version": "6.7.1",
+            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.1.tgz",
+            "integrity": "sha512-yB5CNFa14MbPJcomwNh3wLThtkZgcNyI2bNMRt8iE5Z8Vwl7f8vQXFAzn2HDOJvtDq2NTZBUGMSUNNyrv3/+cw==",
+            "dev": true,
+            "requires": {
+                "icss-utils": "^5.1.0",
+                "postcss": "^8.4.7",
+                "postcss-modules-extract-imports": "^3.0.0",
+                "postcss-modules-local-by-default": "^4.0.0",
+                "postcss-modules-scope": "^3.0.0",
+                "postcss-modules-values": "^4.0.0",
+                "postcss-value-parser": "^4.2.0",
+                "semver": "^7.3.5"
+            }
+        },
         "css-select": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
@@ -4732,6 +4913,12 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
             "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+            "dev": true
+        },
+        "cssesc": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+            "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
             "dev": true
         },
         "debug": {
@@ -4854,9 +5041,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.4.224",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.224.tgz",
-            "integrity": "sha512-dOujC5Yzj0nOVE23iD5HKqrRSDj2SD7RazpZS/b/WX85MtO6/LzKDF4TlYZTBteB+7fvSg5JpWh0sN7fImNF8w==",
+            "version": "1.4.233",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.233.tgz",
+            "integrity": "sha512-ejwIKXTg1wqbmkcRJh9Ur3hFGHFDZDw1POzdsVrB2WZjgRuRMHIQQKNpe64N/qh3ZtH2otEoRoS+s6arAAuAAw==",
             "dev": true
         },
         "encodeurl": {
@@ -5111,13 +5298,6 @@
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true
         },
-        "fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
-            "optional": true
-        },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -5272,14 +5452,6 @@
                 "param-case": "^3.0.4",
                 "relateurl": "^0.2.7",
                 "terser": "^5.10.0"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "8.3.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-                    "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-                    "dev": true
-                }
             }
         },
         "html-webpack-plugin": {
@@ -5370,6 +5542,13 @@
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
             }
+        },
+        "icss-utils": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+            "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+            "dev": true,
+            "requires": {}
         },
         "import-local": {
             "version": "3.1.0",
@@ -5511,6 +5690,17 @@
                 "@types/node": "*",
                 "merge-stream": "^2.0.0",
                 "supports-color": "^8.0.0"
+            },
+            "dependencies": {
+                "supports-color": {
+                    "version": "8.1.1",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+                    "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
             }
         },
         "json-parse-even-better-errors": {
@@ -5670,6 +5860,12 @@
                 "dns-packet": "^5.2.2",
                 "thunky": "^1.0.2"
             }
+        },
+        "nanoid": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+            "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+            "dev": true
         },
         "negotiator": {
             "version": "0.6.3",
@@ -5895,6 +6091,69 @@
             "requires": {
                 "find-up": "^4.0.0"
             }
+        },
+        "postcss": {
+            "version": "8.4.16",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
+            "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+            "dev": true,
+            "requires": {
+                "nanoid": "^3.3.4",
+                "picocolors": "^1.0.0",
+                "source-map-js": "^1.0.2"
+            }
+        },
+        "postcss-modules-extract-imports": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
+            "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+            "dev": true,
+            "requires": {}
+        },
+        "postcss-modules-local-by-default": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
+            "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
+            "dev": true,
+            "requires": {
+                "icss-utils": "^5.0.0",
+                "postcss-selector-parser": "^6.0.2",
+                "postcss-value-parser": "^4.1.0"
+            }
+        },
+        "postcss-modules-scope": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
+            "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
+            "dev": true,
+            "requires": {
+                "postcss-selector-parser": "^6.0.4"
+            }
+        },
+        "postcss-modules-values": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+            "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+            "dev": true,
+            "requires": {
+                "icss-utils": "^5.0.0"
+            }
+        },
+        "postcss-selector-parser": {
+            "version": "6.0.10",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+            "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+            "dev": true,
+            "requires": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+            }
+        },
+        "postcss-value-parser": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+            "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+            "dev": true
         },
         "pretty-error": {
             "version": "4.0.0",
@@ -6295,6 +6554,12 @@
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true
         },
+        "source-map-js": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+            "dev": true
+        },
         "source-map-support": {
             "version": "0.5.21",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -6396,10 +6661,17 @@
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
             "dev": true
         },
+        "style-loader": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
+            "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
+            "dev": true,
+            "requires": {}
+        },
         "supports-color": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
             "dev": true,
             "requires": {
                 "has-flag": "^4.0.0"
@@ -6418,15 +6690,23 @@
             "dev": true
         },
         "terser": {
-            "version": "5.14.2",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-            "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+            "version": "5.15.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
+            "integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
             "dev": true,
             "requires": {
                 "@jridgewell/source-map": "^0.3.2",
                 "acorn": "^8.5.0",
                 "commander": "^2.20.0",
                 "source-map-support": "~0.5.20"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.20.3",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+                    "dev": true
+                }
             }
         },
         "terser-webpack-plugin": {
@@ -6492,9 +6772,9 @@
             }
         },
         "typescript": {
-            "version": "4.7.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-            "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+            "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
             "dev": true
         },
         "unpipe": {
@@ -6686,9 +6966,9 @@
             }
         },
         "webpack-dev-server": {
-            "version": "4.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.10.0.tgz",
-            "integrity": "sha512-7dezwAs+k6yXVFZ+MaL8VnE+APobiO3zvpp3rBHe/HmWQ+avwh0Q3d0xxacOiBybZZ3syTZw9HXzpa3YNbAZDQ==",
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.10.1.tgz",
+            "integrity": "sha512-FIzMq3jbBarz3ld9l7rbM7m6Rj1lOsgq/DyLGMX/fPEB1UBUPtf5iL/4eNfhx8YYJTRlzfv107UfWSWcBK5Odw==",
             "dev": true,
             "requires": {
                 "@types/bonjour": "^3.5.9",

--- a/front/package.json
+++ b/front/package.json
@@ -10,7 +10,9 @@
     "keywords": [],
     "license": "AGPL-3.0-or-later",
     "devDependencies": {
+        "css-loader": "^6.7.1",
         "html-webpack-plugin": "^5.5.0",
+        "style-loader": "^3.3.1",
         "ts-loader": "^9.3.1",
         "typescript": "^4.7.4",
         "webpack": "*",

--- a/front/webpack.common.js
+++ b/front/webpack.common.js
@@ -8,7 +8,12 @@ module.exports = {
             {
                 test: /\.ts$/,
                 use: "ts-loader",
-                exclude: /node_modules/,
+                include: [path.resolve(__dirname, "src/")],
+            },
+            {
+                test: /\.css$/,
+                use: ["style-loader", "css-loader"],
+                include: [path.resolve(__dirname, "src/")],
             },
         ],
     },
@@ -16,7 +21,6 @@ module.exports = {
     resolve: {
         extensions: [".ts", ".js", ".json"],
     },
-
     output: {
         filename: "main.js",
         path: path.resolve(__dirname, "dist"),

--- a/front/webpack.common.js
+++ b/front/webpack.common.js
@@ -8,12 +8,12 @@ module.exports = {
             {
                 test: /\.ts$/,
                 use: "ts-loader",
-                include: [path.resolve(__dirname, "src/")],
+                include: path.resolve(__dirname, "src/"),
             },
             {
                 test: /\.css$/,
                 use: ["style-loader", "css-loader"],
-                include: [path.resolve(__dirname, "src/")],
+                include: path.resolve(__dirname, "src/"),
             },
         ],
     },


### PR DESCRIPTION
This PR adds support for CSS modules to the Webpack configuration. See https://webpack.js.org/loaders/css-loader/.