### PR TITLE
Use 'process.env.NODE_ENV' instead of comparing the URI

### DIFF
--- a/front/src/index.ts
+++ b/front/src/index.ts
@@ -11,7 +11,7 @@ function once(target: EventTarget, name: string) {
 }
 
 function getBackendUrl() {
-    if (location.host === "localhost:9451") {
+    if (process.env.NODE_ENV !== "production") {
         return "ws://localhost:9450";
     }
 


### PR DESCRIPTION
According to the Webpack documentation (https://webpack.js.org/guides/production/):

> Technically, NODE_ENV is a system environment variable that Node.js exposes into running scripts. It is used by convention to determine dev-vs-prod behavior by server tools, build scripts, and client-side libraries.
